### PR TITLE
stdenv substituteAll: fix handling of variables

### DIFF
--- a/doc/stdenv.xml
+++ b/doc/stdenv.xml
@@ -1169,7 +1169,15 @@ PATH=/nix/store/68afga4khv0w...-coreutils-6.12/bin
 echo @foo@
 </programlisting>
 
-    That is, no substitution is performed for undefined variables.</para></listitem>
+    That is, no substitution is performed for undefined variables.</para>
+
+    <para>Environment variables that start with an uppercase letter are filtered out,
+    to prevent global variables (like <literal>HOME</literal>) from accidentally
+    getting substituted.
+    The variables also have to be valid bash “names”, as
+    defined in the bash manpage (alphanumeric or <literal>_</literal>, must not
+    start with a number).</para>
+  </listitem>
   </varlistentry>
 
 

--- a/pkgs/build-support/substitute/substitute-all.nix
+++ b/pkgs/build-support/substitute/substitute-all.nix
@@ -2,6 +2,7 @@
 
 args:
 
+# see the substituteAll in the nixpkgs documentation for usage and constaints
 stdenv.mkDerivation ({
   name = if args ? name then args.name else baseNameOf (toString args.src);
   builder = ./substitute-all.sh;

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -445,7 +445,7 @@ substituteAll() {
 
     # Select all environment variables that start with a lowercase character.
     # Will not work with nix attribute names (and thus env variables) containing '\n'.
-    for envVar in $(env | sed -e $'s/^\([a-z][^=]*\)=.*/\\1/; t \n d'); do
+    for envVar in $(set | sed -e $'s/^\([a-z][^=]*\)=.*/\\1/; t \n d'); do
         if [ "$NIX_DEBUG" = "1" ]; then
             echo "$envVar -> ${!envVar}"
         fi


### PR DESCRIPTION
The problem was uncovered by the grandparent commit. `env` doesn't escape newlines in contents of variables, and we use those e.g. for phases, so we would consider lots of crap. Fortunately `set` command behaves better in this respect.
